### PR TITLE
Sort entire file if no text is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Sort lines of text in Visual Studio Code. The following types of sorting are sup
 
     `{ "key": "f9", "command": "-sortLines.sortLines", "when": "editorTextFocus" }`
 
+# Settings
+
+| Name | Description | Default
+|---|---|---|
+| sortLines.filterBlankLines | _(boolean)_ Filter out blank (empty or whitespace-only) lines. | false
+| sortLines.sortEntireFile | _(boolean)_ Sort entire file if no selection is active. | false
+
 # Install
 
 1. Open VS Code

--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
           "type": "boolean",
           "default": false,
           "description": "Filter out blank (empty or whitespace-only) lines."
+        },
+        "sortLines.sortEntireFile": {
+          "type": "boolean",
+          "default": false,
+          "description": "Sort entire file if no selection is active."
         }
       }
     },

--- a/src/sort-lines.ts
+++ b/src/sort-lines.ts
@@ -5,6 +5,11 @@ type SortingAlgorithm = (a: string, b: string) => number;
 function sortActiveSelection(algorithm: SortingAlgorithm, removeDuplicateValues: boolean): Thenable<boolean> | undefined {
   const textEditor = vscode.window.activeTextEditor;
   const selection = textEditor.selection;
+
+  if (selection.isEmpty && vscode.workspace.getConfiguration('sortLines').get('sortEntireFile') === true) {
+    return sortLines(textEditor, 0, textEditor.document.lineCount - 1, algorithm, removeDuplicateValues);
+  }
+
   if (selection.isSingleLine) {
     return undefined;
   }


### PR DESCRIPTION
Add an option to sort the entire file if no text is currently selected in the editor. The option defaults to `false`, as it could lead to some problems in very large files.

Fixes #36.