### PR TITLE
Add option for line preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Sort lines of text in Visual Studio Code. The following types of sorting are sup
 |---|---|---|---|
 | sortLines.filterBlankLines | _(boolean)_ Filter out blank (empty or whitespace-only) lines. | false
 | sortLines.sortEntireFile | _(boolean)_ Sort entire file if no selection is active. | false
-| sortLines.linePreprocessorRegex | _(string)_ A regex that will be used before running the sorting algorithm, only the first group matched will be used by the algorithm. | | `^[Tt]he (.*)$`
+| sortLines.linePreprocessorRegex | _(string)_ A regex that will be used before running the sorting algorithm. | | `^[Tt]he (.*)$`
+| sortLines.linePreprocessorRegexCaptureGroup | _(number)_ When a regex is used for preprocessing, which group will be used to sort by. | 1
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Sort lines of text in Visual Studio Code. The following types of sorting are sup
 
     `{ "key": "f9", "command": "-sortLines.sortLines", "when": "editorTextFocus" }`
 
+# Settings
+| Name | Description | Default | Example
+|---|---|---|---|
+| sortLines.filterBlankLines | _(boolean)_ Filter out blank (empty or whitespace-only) lines. | false
+| sortLines.linePreprocessorRegex | _(string)_ A regex that will be used before running the sorting algorithm, only the first group matched will be used by the algorithm. | | `^[Tt]he (.*)$`
+
 # Install
 
 1. Open VS Code

--- a/fixtures/preprocess_expected/sortLines
+++ b/fixtures/preprocess_expected/sortLines
@@ -1,0 +1,10 @@
+A Star Is Born
+Ant-Man and the Wasp
+The First Purge
+Hold the Dark
+The House with a Clock in Its Walls
+Night School
+The Nun
+The Predator
+Solo: A Star Wars Story
+Venom

--- a/fixtures/preprocess_expected/sortLinesCaseInsensitive
+++ b/fixtures/preprocess_expected/sortLinesCaseInsensitive
@@ -1,0 +1,10 @@
+A Star Is Born
+Ant-Man and the Wasp
+The First Purge
+Hold the Dark
+The House with a Clock in Its Walls
+Night School
+The Nun
+The Predator
+Solo: A Star Wars Story
+Venom

--- a/fixtures/preprocess_expected/sortLinesCaseInsensitiveUnique
+++ b/fixtures/preprocess_expected/sortLinesCaseInsensitiveUnique
@@ -1,0 +1,10 @@
+A Star Is Born
+Ant-Man and the Wasp
+The First Purge
+Hold the Dark
+The House with a Clock in Its Walls
+Night School
+The Nun
+The Predator
+Solo: A Star Wars Story
+Venom

--- a/fixtures/preprocess_expected/sortLinesLineLength
+++ b/fixtures/preprocess_expected/sortLinesLineLength
@@ -1,0 +1,10 @@
+The Nun
+Venom
+The Predator
+The First Purge
+Night School
+Hold the Dark
+A Star Is Born
+Ant-Man and the Wasp
+Solo: A Star Wars Story
+The House with a Clock in Its Walls

--- a/fixtures/preprocess_expected/sortLinesLineLengthReverse
+++ b/fixtures/preprocess_expected/sortLinesLineLengthReverse
@@ -1,0 +1,10 @@
+The House with a Clock in Its Walls
+Solo: A Star Wars Story
+Ant-Man and the Wasp
+A Star Is Born
+Hold the Dark
+Night School
+The First Purge
+The Predator
+Venom
+The Nun

--- a/fixtures/preprocess_expected/sortLinesNatural
+++ b/fixtures/preprocess_expected/sortLinesNatural
@@ -1,0 +1,10 @@
+A Star Is Born
+Ant-Man and the Wasp
+The First Purge
+Hold the Dark
+The House with a Clock in Its Walls
+Night School
+The Nun
+The Predator
+Solo: A Star Wars Story
+Venom

--- a/fixtures/preprocess_expected/sortLinesReverse
+++ b/fixtures/preprocess_expected/sortLinesReverse
@@ -1,0 +1,10 @@
+Venom
+Solo: A Star Wars Story
+The Predator
+The Nun
+Night School
+The House with a Clock in Its Walls
+Hold the Dark
+The First Purge
+Ant-Man and the Wasp
+A Star Is Born

--- a/fixtures/preprocess_expected/sortLinesUnique
+++ b/fixtures/preprocess_expected/sortLinesUnique
@@ -1,0 +1,10 @@
+A Star Is Born
+Ant-Man and the Wasp
+The First Purge
+Hold the Dark
+The House with a Clock in Its Walls
+Night School
+The Nun
+The Predator
+Solo: A Star Wars Story
+Venom

--- a/fixtures/preprocess_expected/sortLinesVariableLength
+++ b/fixtures/preprocess_expected/sortLinesVariableLength
@@ -1,0 +1,10 @@
+The Nun
+Venom
+The Predator
+The First Purge
+Night School
+Hold the Dark
+A Star Is Born
+Ant-Man and the Wasp
+Solo: A Star Wars Story
+The House with a Clock in Its Walls

--- a/fixtures/preprocess_expected/sortLinesVariableLengthReverse
+++ b/fixtures/preprocess_expected/sortLinesVariableLengthReverse
@@ -1,0 +1,10 @@
+The House with a Clock in Its Walls
+Solo: A Star Wars Story
+Ant-Man and the Wasp
+A Star Is Born
+Hold the Dark
+Night School
+The First Purge
+The Predator
+Venom
+The Nun

--- a/fixtures/preprocess_fixture
+++ b/fixtures/preprocess_fixture
@@ -1,0 +1,10 @@
+Venom
+A Star Is Born
+Hold the Dark
+Night School
+Solo: A Star Wars Story
+The Predator
+Ant-Man and the Wasp
+The Nun
+The House with a Clock in Its Walls
+The First Purge

--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
           "type": "boolean",
           "default": false,
           "description": "Filter out blank (empty or whitespace-only) lines."
+        },
+        "sortLines.linePreprocessorRegex": {
+          "type": "string",
+          "default": "",
+          "description": "A regex that will be used before running the sorting algorithm, only the first group matched will be used by the algorithm."
         }
       }
     },

--- a/src/sort-lines.ts
+++ b/src/sort-lines.ts
@@ -22,7 +22,12 @@ function sortLines(textEditor: vscode.TextEditor, startLine: number, endLine: nu
     removeBlanks(lines);
   }
 
-  lines.sort(algorithm);
+  lines.sort((a, b) => {
+    const left = preprocessLine(a);
+    const right = preprocessLine(b);
+
+    return algorithm ? algorithm(left, right) : left.localeCompare(right);
+  });
 
   if (removeDuplicateValues) {
     removeDuplicates(lines, algorithm);
@@ -32,6 +37,16 @@ function sortLines(textEditor: vscode.TextEditor, startLine: number, endLine: nu
     const range = new vscode.Range(startLine, 0, endLine, textEditor.document.lineAt(endLine).text.length);
     editBuilder.replace(range, lines.join('\n'));
   });
+}
+
+function preprocessLine(text: string): string {
+  const regex = new RegExp(vscode.workspace.getConfiguration('sortLines').get('linePreprocessorRegex'));
+  const matches = text.match(regex);
+
+  if (matches != null) {
+    return matches[1] || text;
+  }
+  return text;
 }
 
 function removeDuplicates(lines: string[], algorithm: SortingAlgorithm | undefined): void {

--- a/src/test/sort-lines.test.ts
+++ b/src/test/sort-lines.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
-import { commands, window, Range, Selection, Uri, TextDocument, TextEditor } from 'vscode';
+import { commands, window, Range, Selection, Uri, TextDocument, TextEditor, workspace } from 'vscode';
 
 function selectAllText(editor: TextEditor): void {
   const selection = new Selection(0, 0, editor.document.lineCount - 1, editor.document.lineAt(editor.document.lineCount - 1).text.length);
@@ -49,7 +49,15 @@ suite('Sort Lines', () => {
           commands.executeCommand('workbench.action.closeActiveEditor').then(() => {
             return window.showTextDocument(Uri.file(path.join(fixtureDir, `${fixture}_fixture`))).then(editor => {
               selectAllText(editor);
-              commands.executeCommand(`sortLines.${extCommand}`).then(() => {
+
+              let execution;
+              if (fixture === 'preprocess') {
+                execution = workspace.getConfiguration('sortLines').update('linePreprocessorRegex', '^[Tt]he (.*)$').then(() => commands.executeCommand(`sortLines.${extCommand}`));
+              } else {
+                execution = commands.executeCommand(`sortLines.${extCommand}`);
+              }
+
+              execution.then(() => {
                 const expectedPath = path.join(fixtureDir, `${fixture}_expected/${extCommand}`);
                 const expected = fs.readFileSync(expectedPath, 'utf8');
                 const actual = getAllText(editor.document);


### PR DESCRIPTION
Add an option for the user manipulate the line that will be fed to the sorting algorithm, using a regular expression. This enables more powerful sorting alternatives without adding to much complexity.

With this regex the user will be able to select a part of a line to use as the sorting parameter, or maybe ignore some words.

![vscode-line-sort](https://user-images.githubusercontent.com/34144667/46911733-25dc1300-cf3b-11e8-9bcc-8bc44d060bec.gif)
> Using `^[Tt]he (.*)$`

Fixes #40.
Fixes #33.