### PR TITLE
Use javascript-natural-sort to sort natural

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
     "typescript": "3.7",
     "vscode-test": "^1.2.3"
   },
-  "icon": "images/icon.png"
+  "icon": "images/icon.png",
+  "dependencies": {
+    "javascript-natural-sort": "^0.7.1"
+  }
 }

--- a/src/sort-lines.ts
+++ b/src/sort-lines.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import naturalSort from 'javascript-natural-sort';
 
 type ArrayTransformer = (lines: string[]) => string[];
 type SortingAlgorithm = (a: string, b: string) => number;
@@ -91,14 +92,6 @@ function variableLengthReverseCompare(a: string, b: string): number {
   return variableLengthCompare(a, b) * -1;
 }
 
-let intlCollator: Intl.Collator;
-function naturalCompare(a: string, b: string): number {
-  if (!intlCollator) {
-    intlCollator = new Intl.Collator(undefined, {numeric: true});
-  }
-  return intlCollator.compare(a, b);
-}
-
 function getVariableCharacters(line: string): string {
   const match = line.match(/(.*)=/);
   if (!match) {
@@ -129,7 +122,7 @@ const transformerSequences = {
   sortLineLengthReverse: [makeSorter(lineLengthReverseCompare)],
   sortVariableLength: [makeSorter(variableLengthCompare)],
   sortVariableLengthReverse: [makeSorter(variableLengthReverseCompare)],
-  sortNatural: [makeSorter(naturalCompare)],
+  sortNatural: [makeSorter(naturalSort)],
   sortShuffle: [shuffleSorter],
   removeDuplicateLines: [removeDuplicates]
 };


### PR DESCRIPTION
The previous implementation sorted in the wrong way.

*Before*
```xml
<item drawable="zooper_free_alt"/>
<item drawable="zooper_free"/>
<item drawable="zooper_pro_alt"/>
<item drawable="zooper_pro"/>
```
*Now*
```xml
<item drawable="zooper_free"/>
<item drawable="zooper_free_alt"/>
<item drawable="zooper_pro"/>
<item drawable="zooper_pro_alt"/>
```
As you can see now it items are sorted in proper natural. Uses [javascript-natural-sort](https://www.npmjs.com/package/javascript-natural-sort) package for sorting in natural.