### PR TITLE
Ability to ignore unselected last line

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
           "default": false,
           "description": "Filter out blank (empty or whitespace-only) lines."
         },
+        "sortLines.ignoreUnselectedLastLine": {
+          "type": "boolean",
+          "default": false,
+          "description": "Ignore unselected last line. Allows selection by line numbers."
+        },
         "sortLines.sortEntireFile": {
           "type": "boolean",
           "default": false,

--- a/src/sort-lines.ts
+++ b/src/sort-lines.ts
@@ -23,7 +23,14 @@ function sortActiveSelection(transformers: ArrayTransformer[]): Thenable<boolean
   if (selection.isSingleLine) {
     return undefined;
   }
-  return sortLines(textEditor, selection.start.line, selection.end.line, transformers);
+
+  let endLine = selection.end.line
+
+  // Ignore unselected last line
+  if (selection.end.character == 0 && vscode.workspace.getConfiguration('sortLines').get('ignoreUnselectedLastLine') === true) {
+    endLine -= 1
+  }
+  return sortLines(textEditor, selection.start.line, endLine, transformers);
 }
 
 function sortLines(textEditor: vscode.TextEditor, startLine: number, endLine: number, transformers: ArrayTransformer[]): Thenable<boolean> {


### PR DESCRIPTION
This adds an option to ignore unselected last line.
This way we can select the lines to sort by the line numbers, which places the cursor at the beginning of the line following the selection, which was sorted without this option.

I personally think it should be the default behavior and no parameter is necessary but I didn't want to cause a breaking change if some users are used to the current behavior.

Fixes #118

Here is a gif showing the different behaviors:
![sortlines2](https://github.com/Tyriar/vscode-sort-lines/assets/1533042/bc9017a2-e862-4492-b338-3391ec3c1616)
