### PR TITLE
added function to sort lines by marked ranges

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('sortLines.sortLinesShuffle', sortLines.sortShuffle),
     vscode.commands.registerCommand('sortLines.removeDuplicateLines', sortLines.removeDuplicateLines),
     vscode.commands.registerCommand('sortLines.keepOnlyDuplicateLines', sortLines.keepOnlyDuplicateLines),
+    vscode.commands.registerCommand('sortLines.sortLinesByMarkedRanges', sortLines.rangeSortNormal),
   ];
 
   commands.forEach(command => context.subscriptions.push(command));

--- a/src/sort-lines.ts
+++ b/src/sort-lines.ts
@@ -4,7 +4,7 @@ type ArrayTransformer = (lines: string[]) => string[];
 type SortingAlgorithm = (a: string, b: string) => number;
 
 function makeSorter(algorithm?: SortingAlgorithm): ArrayTransformer {
-  return function(lines: string[]): string[] {
+  return function (lines: string[]): string[] {
     return lines.sort(algorithm);
   };
 }
@@ -31,6 +31,105 @@ function sortActiveSelection(transformers: ArrayTransformer[]): Thenable<boolean
     endLine -= 1
   }
   return sortLines(textEditor, selection.start.line, endLine, transformers);
+}
+
+function sortByMarkedRanges(): Thenable<boolean> | undefined {
+  const window = vscode.window;
+  const textEditor = window.activeTextEditor;
+
+  if (!textEditor) {
+    return undefined;
+  }
+
+  // class to save the ranges that are to be sorted
+  class SortableLines {
+    lines: string[] = [];
+    startLine: number;
+    endLine: number;
+    transformers: ArrayTransformer[];
+    constructor(startLine: number, endLine: number, transformers: ArrayTransformer[]) {
+      this.startLine = startLine;
+      this.endLine = endLine;
+      this.transformers = transformers;
+    }
+  }
+  let sortableLines: SortableLines[] = [];
+
+
+  // the line the currently tracked range starts at
+  let startLine: number | null = null;
+  // the matched modifier the start of the currently tracked range
+  let startMatch: [string, ArrayTransformer[]] | null = null;
+  // the matched modifier for the currently inspected line
+  let currentMatch: [string, ArrayTransformer[]] | null = null;
+  const transformersSequencesKeyValues = Object.entries(transformerSequences);
+  // iterate through the file and look for marked ranges
+  for (let currentLine = 0; currentLine < textEditor.document.lineCount; currentLine++) {
+    const line = textEditor.document.lineAt(currentLine);
+    currentMatch = null;
+    for (const keyValue of transformersSequencesKeyValues) {
+      if (line.text.match(new RegExp(`${keyValue[0]} |${keyValue[0]}$`))) {
+        if (currentMatch !== null) {
+          window.showErrorMessage("multple sorting specifiers at line " + currentLine);
+          startLine = null;
+          break;
+        }
+        currentMatch = keyValue;
+      }
+    }
+    if (currentMatch !== null) {
+      console.log("match at line " + currentLine + " : " + currentMatch);
+      // only match if start is a separate word
+      if (line.text.match(/start | start/)) {
+        // complain for nested sorting ranges
+        if (startLine !== null) {
+          window.showErrorMessage("nested sorting ranges at lines "
+            + startLine + " and " + currentLine);
+        }
+        console.log("start found: ", currentLine)
+        startMatch = currentMatch;
+        startLine = currentLine + 1;
+      }
+      // only match if end is a separate word
+      else if (line.text.match(/end | end/)) {
+        // complain for ends without a start (will also complain for nested sorting ranges)
+        if (startLine === null || startMatch === null) {
+          window.showErrorMessage("unmatched sorting range end specifier at line " + currentLine);
+        }
+        // complain for mismatched types of sorting
+        else if (currentMatch[0] !== startMatch[0]) {
+          window.showErrorMessage("mismatched sorting modifier '" + startMatch[0]
+            + "' for start at  " + startLine + " and '" + currentMatch[0]
+            + "' end at " + currentLine);
+        } else {
+          console.log("end found: ", currentLine);
+          let index = sortableLines.length;
+          sortableLines.push(new SortableLines(startLine, currentLine, currentMatch[1]));
+          for (let i = startLine; i < currentLine; i++) {
+            sortableLines[index].lines.push(textEditor.document.lineAt(i).text);
+          }
+          startLine = null;
+          startMatch = null;
+        }
+      } else {
+        window.showErrorMessage("found sorting modifier, but neither start nor end to signify a range at line " + currentLine);
+      }
+
+    }
+  }
+  // complain if there is an unclosed range at the end
+  if (startLine !== null) {
+    window.showErrorMessage("found no end for sorting range started at line " + startLine);
+  }
+
+  // create return the resulting edit
+  return textEditor.edit(editBuilder => {
+    sortableLines.forEach(element => {
+      element.lines = element.transformers.reduce((currentLines, transform) => transform(currentLines), element.lines);
+      const range = new vscode.Range(element.startLine, 0, element.endLine - 1, textEditor.document.lineAt(element.endLine).text.length);
+      editBuilder.replace(range, element.lines.join('\n'));
+    });
+  });
 }
 
 function sortLines(textEditor: vscode.TextEditor, startLine: number, endLine: number, transformers: ArrayTransformer[]): Thenable<boolean> {
@@ -77,7 +176,7 @@ function reverseCompare(a: string, b: string): number {
 }
 
 function caseInsensitiveCompare(a: string, b: string): number {
-  return a.localeCompare(b, undefined, {sensitivity: 'base'});
+  return a.localeCompare(b, undefined, { sensitivity: 'base' });
 }
 
 function lineLengthCompare(a: string, b: string): number {
@@ -105,7 +204,7 @@ function variableLengthReverseCompare(a: string, b: string): number {
 let intlCollator: Intl.Collator;
 function naturalCompare(a: string, b: string): number {
   if (!intlCollator) {
-    intlCollator = new Intl.Collator(undefined, {numeric: true});
+    intlCollator = new Intl.Collator(undefined, { numeric: true });
   }
   return intlCollator.compare(a, b);
 }
@@ -123,11 +222,11 @@ function getVariableCharacters(line: string): string {
 }
 
 function shuffleSorter(lines: string[]): string[] {
-    for (let i = lines.length - 1; i > 0; i--) {
-        const rand = Math.floor(Math.random() * (i + 1));
-        [lines[i], lines[rand]] = [lines[rand], lines[i]];
-    }
-    return lines;
+  for (let i = lines.length - 1; i > 0; i--) {
+    const rand = Math.floor(Math.random() * (i + 1));
+    [lines[i], lines[rand]] = [lines[rand], lines[i]];
+  }
+  return lines;
 }
 
 const transformerSequences = {
@@ -159,3 +258,5 @@ export const sortNatural = () => sortActiveSelection(transformerSequences.sortNa
 export const sortShuffle = () => sortActiveSelection(transformerSequences.sortShuffle);
 export const removeDuplicateLines = () => sortActiveSelection(transformerSequences.removeDuplicateLines);
 export const keepOnlyDuplicateLines = () => sortActiveSelection(transformerSequences.keepOnlyDuplicateLines);
+
+export const rangeSortNormal = () => sortByMarkedRanges();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
       "target": "es6",
       "outDir": "out",
       "lib": [
-          "es6"
+          "es2017"
       ],
       "sourceMap": true,
       "rootDir": "src",


### PR DESCRIPTION
completes #125

i didn't write a formatter (sorting on save) in the end, because most of the time you want to have an actual formatter as the formatter for your language and vscode can't have multiple formatters without another extension.
For now, a function i can call every time i need it suffices.

I changed the lib compiler option to TS2017, because I needed the `Object.entries()` function.
Without it, the code was horribly unsafe, indexing the `transformerSequences` with a string, or would have become more complicated.

Feel free to criticize my code, it is probably shitty, since it is the first JavaScript or TypeScript code I ever wrote.

If you don't want the random edits the JS formatter made at the other places in the file, i can revert that if you want.

If you don't want this in your extension at all, it's also fine, i can just use my own version and anyone else will probably be able to find my fork through this.

Also, this is not really tested enough, that's why i made it a draft for now.